### PR TITLE
docs: remove explicit package syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ Have a look at our [instructions for contributors](CONTRIBUTING.md).
 
 ```bash
 git clone https://github.com/ankilangs/ankilangs
-cd ankilangs
-uv sync
+cd ankilangs/
 ```
 
 ### Build the decks


### PR DESCRIPTION
`uv` implicitly syncs all dependencies on relevant invocations, so manually running `uv sync` beforehand is not needed. See
https://docs.astral.sh/uv/concepts/projects/sync/#automatic-lock-and-sync

Also just write out that slash to show it is a directory.